### PR TITLE
add serialport communication, fuel_level command, reduce unwrap()s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 
 [dependencies]
 env_logger = "0.10"
-ftdi = "0.1.3"
 log = "0.4.8"
 thiserror = "1.0.15"
+ftdi = { version = "0.1.3", optional = true }
+serialport= { version = "=4.6.1", optional = true }
+
+[features]
+ftdi_comm = [ "dep:ftdi" ]
+serialport_comm = [ "dep:serialport" ]

--- a/README.md
+++ b/README.md
@@ -9,13 +9,20 @@ vehicle.
 ## Usage
 
 ```rs
-use obd2::{commands::Obd2DataRetrieval, device::Elm327, Obd2};
+use obd2::{commands::Obd2DataRetrieval, device::{Elm327, FTDIDevice}, Obd2};
 
 fn main() -> Result<(), obd2::Error> {
-    let mut device = Obd2::<Elm327>::default();
+    let mut device = Obd2::new(Elm327::new(FTDIDevice::new()?)?)?;
     println!("VIN: {}", device.get_vin()?);
     Ok(())
 }
+```
+
+alternatively, you could use a serial port provided by your operating system such as
+/dev/ttyUSB0 on unix-like systems
+
+```rs
+let mut device = Obd2::new(Elm327::new(SerialPort::new("/dev/ttyUSB0")?)?)?;
 ```
 
 See the docs for more: https://docs.rs/obd2/

--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -2,15 +2,16 @@ use obd2::commands::Obd2DataRetrieval;
 
 use std::time;
 
-fn main() {
+fn main() -> Result<(), obd2::Error> {
     env_logger::init();
-    let mut device: obd2::Obd2<obd2::device::Elm327> = obd2::Obd2::default();
+    let mut device: obd2::Obd2<obd2::device::Elm327<obd2::device::FTDIDevice>> =
+        obd2::Obd2::new(obd2::device::Elm327::new(obd2::device::FTDIDevice::new()?)?)?;
 
     println!("VIN: {:?}", device.get_vin());
-    for s in device.get_service_1_pid_support_1().unwrap().iter() {
+    for s in device.get_service_1_pid_support_1()?.iter() {
         println!("PID support ($01-$20): {:08X}", s);
     }
-    for s in device.get_service_1_pid_support_2().unwrap().iter() {
+    for s in device.get_service_1_pid_support_2()?.iter() {
         println!("PID support ($21-$40): {:08X}", s);
     }
 
@@ -47,4 +48,6 @@ fn main() {
             device.get_throttle_position()
         );
     }
+
+    Ok(())
 }

--- a/src/device/ftdi_comm.rs
+++ b/src/device/ftdi_comm.rs
@@ -1,0 +1,42 @@
+use super::serial_comm::{SerialComm, DEFAULT_BAUD_RATE};
+use super::Result;
+use std::io::{Read, Write};
+
+/// Communicate with a USB to Serial FTDI device
+/// with the FTDI library
+pub struct FTDIDevice {
+    device: ftdi::Device,
+}
+
+impl FTDIDevice {
+    /// Creates a new instance of an FTDIDevice
+    pub fn new() -> Result<Self> {
+        let mut device = ftdi::find_by_vid_pid(0x0404, 0x6001)
+            .interface(ftdi::Interface::A)
+            .open()?;
+
+        device.set_baud_rate(DEFAULT_BAUD_RATE)?;
+        device.configure(ftdi::Bits::Eight, ftdi::StopBits::One, ftdi::Parity::None)?;
+        device.usb_reset()?;
+
+        Ok(Self { device })
+    }
+}
+
+impl SerialComm for FTDIDevice {
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        Ok(self.device.write_all(data)?)
+    }
+
+    fn read(&mut self, data: &mut [u8]) -> Result<usize> {
+        Ok(self.device.read(data)?)
+    }
+
+    fn set_baud_rate(&mut self, baud_rate: u32) -> Result<()> {
+        Ok(self.device.set_baud_rate(baud_rate)?)
+    }
+
+    fn purge_buffers(&mut self) -> Result<()> {
+        Ok(self.device.usb_purge_buffers()?)
+    }
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -3,6 +3,18 @@
 mod elm327;
 pub use elm327::Elm327;
 
+mod serial_comm;
+
+#[cfg(feature = "ftdi_comm")]
+mod ftdi_comm;
+#[cfg(feature = "ftdi_comm")]
+pub use ftdi_comm::FTDIDevice;
+
+#[cfg(feature = "serialport_comm")]
+mod serialport_comm;
+#[cfg(feature = "serialport_comm")]
+pub use serialport_comm::SerialPort;
+
 type Result<T> = std::result::Result<T, Error>;
 
 /// A lower-level API for using an OBD-II device
@@ -51,8 +63,14 @@ pub trait Obd2Reader {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// An error with the underlying [FTDI device](ftdi::Device)
+    #[cfg(feature = "ftdi_comm")]
     #[error("FTDI error: `{0:?}`")]
     Ftdi(ftdi::Error),
+
+    /// An error with the underlying [serialport device](serialport::SerialPort)
+    #[cfg(feature = "serialport_comm")]
+    #[error("Serialport error: `{0:?}`")]
+    Serialport(serialport::Error),
 
     /// An I/O error in a low-level [std::io] stream operation
     #[error("IO error: `{0:?}`")]
@@ -63,9 +81,17 @@ pub enum Error {
     Communication(String),
 }
 
+#[cfg(feature = "ftdi_comm")]
 impl From<ftdi::Error> for Error {
     fn from(e: ftdi::Error) -> Self {
         Error::Ftdi(e)
+    }
+}
+
+#[cfg(feature = "serialport_comm")]
+impl From<serialport::Error> for Error {
+    fn from(e: serialport::Error) -> Self {
+        Error::Serialport(e)
     }
 }
 

--- a/src/device/serial_comm.rs
+++ b/src/device/serial_comm.rs
@@ -1,0 +1,12 @@
+use super::Result;
+
+#[cfg(any(feature = "serialport_comm", feature = "ftdi_comm"))]
+pub const DEFAULT_BAUD_RATE: u32 = 38_400;
+
+/// An API to communicate with a serial device
+pub trait SerialComm {
+    fn write_all(&mut self, data: &[u8]) -> Result<()>;
+    fn read(&mut self, data: &mut [u8]) -> Result<usize>;
+    fn set_baud_rate(&mut self, baud_rate: u32) -> Result<()>;
+    fn purge_buffers(&mut self) -> Result<()>;
+}

--- a/src/device/serialport_comm.rs
+++ b/src/device/serialport_comm.rs
@@ -1,0 +1,46 @@
+use super::serial_comm::{SerialComm, DEFAULT_BAUD_RATE};
+use super::Result;
+use std::io::{Read, Write};
+use std::time::Duration;
+
+/// Communicate with a serial device using the
+/// serialport library
+///
+/// /dev/tty* or similar on unix-like systems
+/// COM devices on Windows systems
+pub struct SerialPort {
+    device: Box<dyn serialport::SerialPort>,
+}
+
+impl SerialPort {
+    /// Creates a new instance of a SerialPort
+    pub fn new(path: &str) -> Result<Self> {
+        let device = serialport::new(path, DEFAULT_BAUD_RATE)
+            .timeout(Duration::from_millis(10))
+            .parity(serialport::Parity::None)
+            .data_bits(serialport::DataBits::Eight)
+            .stop_bits(serialport::StopBits::One)
+            .path(path)
+            .open()?;
+
+        Ok(Self { device })
+    }
+}
+
+impl SerialComm for SerialPort {
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        Ok(self.device.write_all(data)?)
+    }
+
+    fn read(&mut self, data: &mut [u8]) -> Result<usize> {
+        Ok(self.device.read(data)?)
+    }
+
+    fn set_baud_rate(&mut self, baud_rate: u32) -> Result<()> {
+        Ok(self.device.set_baud_rate(baud_rate)?)
+    }
+
+    fn purge_buffers(&mut self) -> Result<()> {
+        Ok(self.device.clear(serialport::ClearBuffer::All)?)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,6 @@
+//! Error types for OBD-II related errors
+
+/// Result type defaulted with this library's error type
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An error with OBD-II communication
@@ -16,8 +19,9 @@ pub enum Error {
     Other(String),
 }
 
+/// An error with the ELM327 device
 #[derive(Debug)]
-pub struct DeviceError(crate::device::Error);
+pub struct DeviceError(pub crate::device::Error);
 
 impl From<super::device::Error> for Error {
     fn from(e: super::device::Error) -> Self {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -6,7 +6,6 @@ use super::{device::Obd2BaseDevice, Error, Obd2Device, Result};
 ///
 /// Wraps an implementer of [Obd2BaseDevice] to allow for higher-level usage of the OBD-II
 /// interface.
-#[derive(Default)]
 pub struct Obd2<T: Obd2BaseDevice> {
     device: T,
 }
@@ -43,6 +42,18 @@ impl<T: Obd2BaseDevice> Obd2Device for Obd2<T> {
 }
 
 impl<T: Obd2BaseDevice> Obd2<T> {
+    /// Creates a new instance of an Obd device
+    pub fn new(dev: T) -> Result<Self> {
+        let device = Obd2 { device: dev };
+
+        Ok(device)
+    }
+
+    /// Resets the device
+    pub fn reset(&mut self) -> Result<()> {
+        Ok(self.device.reset()?)
+    }
+
     fn command(&mut self, command: &[u8]) -> Result<Vec<Vec<u8>>> {
         let response = self
             .device

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,19 @@
 //!
 //! # Usage
 //! ```
-//! use obd2::{commands::Obd2DataRetrieval, device::Elm327, Obd2};
+//! use obd2::{commands::Obd2DataRetrieval, device::{Elm327, FTDIDevice}, Obd2};
 //!
 //! fn main() -> Result<(), obd2::Error> {
-//!     let mut device = Obd2::<Elm327>::default();
+//!     let mut device = Obd2::new(Elm327::new(FTDIDevice::new()?)?)?;
 //!     println!("VIN: {}", device.get_vin()?);
 //!     Ok(())
 //! }
+//! ```
+//!
+//! alternatively, you could use a serial port provided by your operating system such as
+//! /dev/ttyUSB0 on unix-like systems
+//! ```
+//! let mut device = Obd2::new(Elm327::new(SerialPort::new("/dev/ttyUSB0")?)?)?;
 //! ```
 
 #![forbid(unsafe_code)]


### PR DESCRIPTION
This PR makes the following changes:

- allow communication to elm327 device via a serialport (i.e. /dev/tty*)
- allow creation of elm327 device without requiring unwrap()
- added some extra documentation
- add fuel_level obd-ii command
- expose reset() functionality of device

I can break these up into a couple of smaller PRs if preferred, some of these build off of each other so one big PR seemed like an okay idea. 

I tested it with the new SerialPort communication layer, but did not get a chance to test it with the FTDIDevice communication layer, as the ELM327 reader I have uses some knockoff ftdi chip that doesn't seem to play well with the library, and most of the testing I did was with an ELM327 emulator. Testing it with a proper FTDI device before merging would be a good idea.

 